### PR TITLE
Feature: replace fake tabs with HTML space entities.

### DIFF
--- a/src/common/CHANGES.md
+++ b/src/common/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+2018-06-18: v2.13.3.1
+---------------------
+
+* [Feature #1](https://github.com/NyanKiyoshi/markdown-here/pull/1): Replacing fake tabs (`\t`) to HTML spaces entities.
+
 2017-xx-yy: v2.13.3
 --------------------
 

--- a/src/common/marked.js
+++ b/src/common/marked.js
@@ -6,12 +6,17 @@
 
 ;(function() {
 
+const TAB_NUMBER_SPACES = 2;
+const HTML_SPACE_ENTITY = '&nbsp;';
+const SINGLE_TAB = HTML_SPACE_ENTITY.repeat(TAB_NUMBER_SPACES);
+
 /**
  * Block-Level Grammar
  */
 
 var block = {
   newline: /^\n+/,
+  tabulation: /^\\t/,
   code: /^( {4}[^\n]+\n*)+/,
   fences: noop,
   hr: /^( *[-*_]){3,} *(?:\n+|$)/,
@@ -167,6 +172,16 @@ Lexer.prototype.token = function(src, top, bq) {
           type: 'space'
         });
       }
+    }
+
+    // tabulations
+    let tabCount = 0;
+    while (cap = this.rules.tabulation.exec(src)) {
+      src = src.substring(cap[0].length);
+      ++tabCount;
+    }
+    if (tabCount) {
+      src = SINGLE_TAB.repeat(tabCount) + src;
     }
 
     // code

--- a/src/common/test/markdown-render-test.js
+++ b/src/common/test/markdown-render-test.js
@@ -31,6 +31,18 @@ describe('Markdown-Render', function() {
       expect(MarkdownRender.markdownRender('', userprefs, marked, hljs)).to.equal('');
     });
 
+    it('should replace single fake tab at the line beginning with 2 spaces', function() {
+      var s = '\\tHello World!';
+      var target = '<p>&nbsp;&nbsp;Hello World!</p>\n';
+      expect(MarkdownRender.markdownRender(s, userprefs, marked, hljs)).to.equal(target);
+    });
+
+    it('should replace fake 3 tabs at the line beginning with 6 spaces', function() {
+      var s = '\\t\\t\\tHello World!';
+      var target = '<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Hello World!</p>\n';
+      expect(MarkdownRender.markdownRender(s, userprefs, marked, hljs)).to.equal(target);
+    });
+
     // Test the fix for https://github.com/adam-p/markdown-here/issues/51
     it('should correctly handle links with URL text', function() {
       var s = '[http://example1.com](http://example2.com)';


### PR DESCRIPTION
Useful for Thunderbird to use a fixed tab width without triggering a code block.

Example:

```markdown
\t\tMy paragraph.
```

```html
&nbsp;&nbsp;&nbsp;&nbsp;My paragraph.
```